### PR TITLE
docs: add deployment and docker management guides

### DIFF
--- a/docs/docker_management.md
+++ b/docs/docker_management.md
@@ -1,0 +1,63 @@
+# Docker Management Commands
+
+This document lists common Docker commands for building, running, and managing the GPT-2 service container.
+
+## Build the Image
+```bash
+docker build -t gpt2-service .
+```
+Builds the image defined by the repository's `Dockerfile` and tags it as `gpt2-service`.
+
+## Run the Service
+```bash
+docker run -d \
+  -p 80:8080 \
+  -v /root/model.pth:/app/model.pth \
+  -e CKPT_PATH=/app/model.pth \
+  --name gpt2-container \
+  gpt2-service
+```
+Runs the container in detached mode with the required port mapping, model weights, and environment variable. The container is named `gpt2-container` for easier management.
+
+## Check Running Containers
+```bash
+docker ps
+```
+Shows running containers. Add `-a` to include stopped containers.
+
+## View Logs
+```bash
+docker logs gpt2-container
+```
+Displays the container's stdout/stderr logs. Add `-f` to follow in real time.
+
+## Stop the Service
+```bash
+docker stop gpt2-container
+```
+Gracefully stops the running container.
+
+## Start the Service Again
+```bash
+docker start gpt2-container
+```
+Starts a stopped container without rebuilding the image.
+
+## Remove the Container
+```bash
+docker rm gpt2-container
+```
+Deletes the container. Use `-f` to force removal if it is running.
+
+## Remove the Image
+```bash
+docker rmi gpt2-service
+```
+Deletes the image. Ensure no containers are using it before removal.
+
+## Check Disk Usage
+```bash
+docker system df
+```
+Displays disk usage by images, containers, and volumes.
+

--- a/docs/droplet_deployment.md
+++ b/docs/droplet_deployment.md
@@ -1,0 +1,72 @@
+# Deployment on DigitalOcean Droplet
+
+Follow these steps to deploy the GPT-2 service using a Docker container on a DigitalOcean Droplet.
+
+## 1. Create a Droplet
+1. Log in to DigitalOcean and create a new droplet with the **Ubuntu 22.04 LTS** image.
+2. Choose a **Basic** droplet plan with **at least 2 vCPUs and 4 GB RAM** for comfortable inference.
+3. Select a region near your users, enable SSH authentication, and create the droplet.
+
+## 2. Secure Networking
+1. In the DigitalOcean dashboard, enable the firewall.
+2. Allow inbound ports **22** (SSH) and **80** or **8080** (HTTP). Add **443** if HTTPS will be used.
+
+## 3. SSH into the Droplet
+```bash
+ssh root@YOUR_DROPLET_IP
+```
+
+## 4. Update and Install Dependencies
+```bash
+apt update && apt upgrade -y
+apt install -y docker.io git
+systemctl enable --now docker
+```
+
+## 5. Clone the Repository and Provide Model Weights
+```bash
+git clone https://github.com/your-org/LLMs.git
+cd LLMs
+```
+Upload your `.pth` model weights to the droplet (for example via `scp`) and note the path, such as `/root/model.pth`.
+
+## 6. Configure Environment Variables
+Configure the service using the following variables before running the container:
+- `CKPT_PATH`: path to the model weights inside the container
+- `MODEL_NAME`: model name to display in the API
+- `TORCH_THREADS`: number of CPU threads for PyTorch
+- `MAX_CTX`: maximum context length
+- `API_KEY` *(optional)*: required API key for requests
+
+## 7. Build the Docker Image
+```bash
+docker build -t gpt2-service .
+```
+This Dockerfile sets up the FastAPI app and GPT-2 model environment.
+
+## 8. Run the Service
+```bash
+docker run -d \
+  -p 80:8080 \
+  -v /root/model.pth:/app/model.pth \
+  -e CKPT_PATH=/app/model.pth \
+  gpt2-service
+```
+
+## 9. Test the API
+- Health check:
+  ```bash
+  curl http://YOUR_DROPLET_IP/health
+  ```
+- Text generation:
+  ```bash
+  curl -X POST "http://YOUR_DROPLET_IP/generate" \
+    -H "Content-Type: application/json" \
+    -d '{"prompt":"The quick brown fox","max_new_tokens":12}'
+  ```
+
+## 10. Optional Production Hardening
+- Use `ufw` to tighten firewall rules.
+- Set up HTTPS with a reverse proxy such as Nginx or Caddy.
+- Configure a process manager or orchestrator for restarts and scaling.
+


### PR DESCRIPTION
## Summary
- document DigitalOcean droplet deployment steps
- add Docker command reference for service management

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad46b3cf488331b2a0f69192552ca1